### PR TITLE
feat: add Baileys bot example with OpenAI classification

### DIFF
--- a/examples/whatsapp-bot.ts
+++ b/examples/whatsapp-bot.ts
@@ -1,0 +1,79 @@
+import makeWASocket, { useMultiFileAuthState } from 'baileys';
+import P from 'pino';
+import OpenAI from 'openai';
+import path from 'path';
+
+// categorías posibles
+const CATEGORIES = ['venta', 'alquiler', 'otro'] as const;
+type Category = typeof CATEGORIES[number];
+
+// respuestas predeterminadas para cada categoría
+const PREDEFINED: Record<Category, { text: string; media: any }> = {
+  venta: {
+    text: 'Gracias por su interés en nuestra opción de venta.',
+    media: {
+      image: {
+        url: 'https://samplelib.com/lib/preview/jpg/sample-5s.jpg'
+      },
+      caption: 'Imagen de venta'
+    }
+  },
+  alquiler: {
+    text: 'Gracias por consultar por alquiler.',
+    media: {
+      video: {
+        url: 'https://samplelib.com/lib/preview/mp4/sample-5s.mp4'
+      },
+      caption: 'Video de alquiler'
+    }
+  },
+  otro: {
+    text: 'Gracias por contactarnos. En breve responderemos.',
+    media: {
+      document: {
+        url: 'https://samplelib.com/lib/preview/pdf/sample-5s.pdf'
+      },
+      mimetype: 'application/pdf',
+      fileName: 'informacion.pdf'
+    }
+  }
+};
+
+// clasifica el mensaje utilizando OpenAI
+async function classifyMessage(text: string): Promise<Category> {
+  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const response = await openai.responses.create({
+    model: 'gpt-4o-mini',
+    input: `Clasifica el mensaje como "venta", "alquiler" o "otro": ${text}`
+  });
+  const output = response.output_text.toLowerCase();
+  if (output.includes('venta')) return 'venta';
+  if (output.includes('alquiler')) return 'alquiler';
+  return 'otro';
+}
+
+async function startBot() {
+  const { state, saveCreds } = await useMultiFileAuthState(path.join(__dirname, 'auth'));
+  const sock = makeWASocket({
+    auth: state,
+    logger: P({ level: 'silent' }),
+    printQRInTerminal: true
+  });
+  sock.ev.on('creds.update', saveCreds);
+
+  sock.ev.on('messages.upsert', async ({ messages }) => {
+    const msg = messages[0];
+    if (!msg.message || msg.key.fromMe) return;
+
+    const body = msg.message.conversation || msg.message.extendedTextMessage?.text || '';
+    if (!body) return;
+
+    const category = await classifyMessage(body);
+    const predefined = PREDEFINED[category];
+
+    await sock.sendMessage(msg.key.remoteJid!, { text: predefined.text });
+    await sock.sendMessage(msg.key.remoteJid!, predefined.media);
+  });
+}
+
+startBot().catch(err => console.error('Error al iniciar bot', err));

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "db:deploy:win": "node runWithProvider.js \"xcopy /E /I prisma\\DATABASE_PROVIDER-migrations prisma\\migrations && npx prisma migrate deploy --schema prisma\\DATABASE_PROVIDER-schema.prisma\"",
     "db:studio": "node runWithProvider.js \"npx prisma studio --schema ./prisma/DATABASE_PROVIDER-schema.prisma\"",
     "db:migrate:dev": "node runWithProvider.js \"rm -rf ./prisma/migrations && cp -r ./prisma/DATABASE_PROVIDER-migrations ./prisma/migrations && npx prisma migrate dev --schema ./prisma/DATABASE_PROVIDER-schema.prisma && cp -r ./prisma/migrations/* ./prisma/DATABASE_PROVIDER-migrations\"",
-    "db:migrate:dev:win": "node runWithProvider.js \"xcopy /E /I prisma\\DATABASE_PROVIDER-migrations prisma\\migrations && npx prisma migrate dev --schema prisma\\DATABASE_PROVIDER-schema.prisma\""
+    "db:migrate:dev:win": "node runWithProvider.js \"xcopy /E /I prisma\\DATABASE_PROVIDER-migrations prisma\\migrations && npx prisma migrate dev --schema prisma\\DATABASE_PROVIDER-schema.prisma\"",
+    "example:bot": "tsnd --transpile-only examples/whatsapp-bot.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- add example WhatsApp bot using Baileys
- classify incoming messages with OpenAI into venta, alquiler or otro
- reply with predefined message and media for each category
- fetch all media from remote URLs instead of bundling files

## Testing
- `npm test` *(fails: Cannot find module './test/all.test.ts')*
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_6893e72428588324a9633ea5f6ce1cec