### PR TITLE
chore: install build tools for native modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine AS builder
 
 RUN apk update && \
-    apk add --no-cache git ffmpeg wget curl bash openssl
+    apk add --no-cache git ffmpeg wget curl bash openssl g++ make python3
 
 LABEL version="2.3.0" description="Api to control whatsapp features through http requests." 
 LABEL maintainer="Davidson Gomes" git="https://github.com/DavidsonGomes"


### PR DESCRIPTION
## Summary
- install build tools in Dockerfile so native Node modules compile

## Testing
- `npm install`
- `npm test` *(fails: Cannot find module './test/all.test.ts')*
- `docker build -t evolution-api-test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_6893f21017e88324b54b32388af36af6