### PR TITLE
feat: validate OpenAI key in WhatsApp bot example

### DIFF
--- a/examples/whatsapp-bot.ts
+++ b/examples/whatsapp-bot.ts
@@ -3,6 +3,8 @@ import P from 'pino';
 import OpenAI from 'openai';
 import path from 'path';
 
+// This example requires the OPENAI_API_KEY environment variable to be set.
+
 // categorías posibles
 const CATEGORIES = ['venta', 'alquiler', 'otro'] as const;
 type Category = typeof CATEGORIES[number];
@@ -41,7 +43,11 @@ const PREDEFINED: Record<Category, { text: string; media: any }> = {
 
 // clasifica el mensaje utilizando OpenAI
 async function classifyMessage(text: string): Promise<Category> {
-  const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY environment variable is required');
+  }
+  const openai = new OpenAI({ apiKey });
   const response = await openai.responses.create({
     model: 'gpt-4o-mini',
     input: `Clasifica el mensaje como "venta", "alquiler" o "otro": ${text}`


### PR DESCRIPTION
## Summary
- check OPENAI_API_KEY before creating OpenAI client in WhatsApp bot example
- document OPENAI_API_KEY requirement in example

## Testing
- `npm test` *(fails: Cannot find module './test/all.test.ts')*
- `npm run lint:check`


------
https://chatgpt.com/codex/tasks/task_e_6893f20d00188324926be13a8662acf8